### PR TITLE
Revamp portfolio into modern dark-themed single-page design

### DIFF
--- a/Styles/main.css
+++ b/Styles/main.css
@@ -1,150 +1,716 @@
-.warning{
-	background-color: red;
-	padding: 40px;
-	margin: 0%;
-	font-size: 50px;
-	color: white;
+/* ============================================
+   MODERN PORTFOLIO – POB VUTISALCHAVAKUL
+   ============================================ */
+
+/* ---------- RESET & TOKENS ---------- */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --clr-bg:          #0a0e1a;
+  --clr-bg-dark:     #060911;
+  --clr-surface:     #111827;
+  --clr-surface-2:   #1a2236;
+  --clr-border:      rgba(99, 102, 241, 0.15);
+  --clr-primary:     #6366f1;
+  --clr-primary-h:   #818cf8;
+  --clr-accent:      #22d3ee;
+  --clr-text:        #f1f5f9;
+  --clr-muted:       #94a3b8;
+  --clr-dim:         #475569;
+
+  --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-mono: 'JetBrains Mono', monospace;
+
+  --radius-sm: 6px;
+  --radius-md: 12px;
+  --radius-lg: 20px;
+
+  --shadow-glow: 0 0 40px rgba(99, 102, 241, 0.15);
+  --shadow-card: 0 4px 24px rgba(0, 0, 0, 0.4);
+
+  --transition: 0.25s ease;
+  --transition-slow: 0.5s ease;
 }
 
-.workwith{
-	background-color: #5A527B;
-	color: white;
-	padding: 40px;
-	margin-top: 0%;
-	font-size: 50px;
-	clear: both;
+html { scroll-behavior: smooth; }
+
+body {
+  font-family: var(--font-sans);
+  background-color: var(--clr-bg);
+  color: var(--clr-text);
+  line-height: 1.6;
+  overflow-x: hidden;
 }
 
-.letsconnect{
-	background-color: #009900;
-	color: white;
-	padding: 20px 40px 40px 40px;
-	margin-top: 0%;
-	font-size: 50px;
+/* Scrollbar */
+::-webkit-scrollbar { width: 6px; }
+::-webkit-scrollbar-track { background: var(--clr-bg-dark); }
+::-webkit-scrollbar-thumb { background: var(--clr-primary); border-radius: 3px; }
+
+/* ---------- UTILITIES ---------- */
+.container {
+  width: min(1100px, 100%);
+  margin-inline: auto;
+  padding-inline: 24px;
 }
 
-.skillset{
-	
-	background: background: rgba(255,255,255,1);
-background: -moz-linear-gradient(top, rgba(255,255,255,1) 0%, rgba(255,255,255,1) 12%, rgba(209,209,209,1) 100%);
-background: -webkit-gradient(left top, left bottom, color-stop(0%, rgba(255,255,255,1)), color-stop(12%, rgba(255,255,255,1)), color-stop(100%, rgba(209,209,209,1)));
-background: -webkit-linear-gradient(top, rgba(255,255,255,1) 0%, rgba(255,255,255,1) 12%, rgba(209,209,209,1) 100%);
-background: -o-linear-gradient(top, rgba(255,255,255,1) 0%, rgba(255,255,255,1) 12%, rgba(209,209,209,1) 100%);
-background: -ms-linear-gradient(top, rgba(255,255,255,1) 0%, rgba(255,255,255,1) 12%, rgba(209,209,209,1) 100%);
-background: linear-gradient(to bottom, rgba(255,255,255,1) 0%, rgba(255,255,255,1) 12%, rgba(209,209,209,1) 100%);
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ffffff', endColorstr='#d1d1d1', GradientType=0 );
-	padding: 45px;
-	margin: 0%;
-	font-size: 40px;
+a { text-decoration: none; color: inherit; }
+
+/* ---------- REVEAL ANIMATIONS ---------- */
+.reveal {
+  opacity: 0;
+  transform: translateY(32px);
+  transition: opacity 0.7s ease, transform 0.7s ease;
+}
+.reveal--delay-1 { transition-delay: 0.1s; }
+.reveal--delay-2 { transition-delay: 0.2s; }
+.reveal--delay-3 { transition-delay: 0.35s; }
+.reveal--delay-4 { transition-delay: 0.5s; }
+.reveal--delay-5 { transition-delay: 0.65s; }
+.reveal.is-visible { opacity: 1; transform: translateY(0); }
+
+/* ---------- NAVIGATION ---------- */
+.nav {
+  position: fixed;
+  inset: 0 0 auto 0;
+  z-index: 100;
+  padding: 0 24px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  background: rgba(10, 14, 26, 0.85);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid transparent;
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+.nav.scrolled {
+  border-color: var(--clr-border);
+  box-shadow: 0 4px 24px rgba(0,0,0,0.4);
+}
+.nav__inner {
+  width: 100%;
+  max-width: 1100px;
+  margin-inline: auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.nav__logo {
+  font-family: var(--font-mono);
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--clr-text);
+  letter-spacing: -0.5px;
+}
+.nav__logo span { color: var(--clr-primary); }
+
+.nav__links {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  list-style: none;
+}
+.nav__link {
+  padding: 8px 12px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--clr-muted);
+  border-radius: var(--radius-sm);
+  transition: color var(--transition), background var(--transition);
+}
+.nav__link:hover { color: var(--clr-text); background: var(--clr-surface); }
+
+.nav__cta {
+  margin-left: 8px;
+  padding: 8px 16px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--clr-primary);
+  border: 1px solid var(--clr-primary);
+  border-radius: var(--radius-sm);
+  transition: background var(--transition), color var(--transition);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.nav__cta:hover { background: rgba(99, 102, 241, 0.15); color: var(--clr-primary-h); }
+
+.nav__toggle {
+  display: none;
+  flex-direction: column;
+  gap: 5px;
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 4px;
+}
+.nav__toggle span {
+  display: block;
+  width: 24px;
+  height: 2px;
+  background: var(--clr-text);
+  border-radius: 2px;
+  transition: var(--transition);
+}
+.nav__toggle.open span:nth-child(1) { transform: translateY(7px) rotate(45deg); }
+.nav__toggle.open span:nth-child(2) { opacity: 0; }
+.nav__toggle.open span:nth-child(3) { transform: translateY(-7px) rotate(-45deg); }
+
+/* ---------- HERO ---------- */
+.hero {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 80px 24px 60px;
+  overflow: hidden;
 }
 
-
-.resume{
-	background-color: #E2E2E2;
+.hero__bg {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+.hero__grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(99, 102, 241, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(99, 102, 241, 0.05) 1px, transparent 1px);
+  background-size: 60px 60px;
+  mask-image: radial-gradient(ellipse 80% 80% at 50% 50%, black 40%, transparent 100%);
+}
+.hero__glow {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(80px);
+  opacity: 0.4;
+  pointer-events: none;
+}
+.hero__glow--1 {
+  width: 600px; height: 600px;
+  background: radial-gradient(circle, rgba(99,102,241,0.3) 0%, transparent 70%);
+  top: -100px; left: -100px;
+}
+.hero__glow--2 {
+  width: 500px; height: 500px;
+  background: radial-gradient(circle, rgba(34,211,238,0.2) 0%, transparent 70%);
+  bottom: -50px; right: -50px;
 }
 
-.pobbody{
-	margin-bottom: 0px;
+.hero__content {
+  position: relative;
+  z-index: 1;
+  max-width: 800px;
+  text-align: center;
 }
 
-.intro{
-	margin: 0%;
-	padding: 5% 0px 0px 0px;
-	font-size: 500%;
+.hero__greeting {
+  font-family: var(--font-mono);
+  font-size: 1rem;
+  color: var(--clr-accent);
+  letter-spacing: 0.1em;
+  margin-bottom: 12px;
 }
 
-.introcon{
-	margin-top: 0px;
-	background: background: rgba(255,255,255,1);
-background: -moz-linear-gradient(top, rgba(255,255,255,1) 0%, rgba(255,255,255,1) 12%, rgba(209,209,209,1) 100%);
-background: -webkit-gradient(left top, left bottom, color-stop(0%, rgba(255,255,255,1)), color-stop(12%, rgba(255,255,255,1)), color-stop(100%, rgba(209,209,209,1)));
-background: -webkit-linear-gradient(top, rgba(255,255,255,1) 0%, rgba(255,255,255,1) 12%, rgba(209,209,209,1) 100%);
-background: -o-linear-gradient(top, rgba(255,255,255,1) 0%, rgba(255,255,255,1) 12%, rgba(209,209,209,1) 100%);
-background: -ms-linear-gradient(top, rgba(255,255,255,1) 0%, rgba(255,255,255,1) 12%, rgba(209,209,209,1) 100%);
-background: linear-gradient(to bottom, rgba(255,255,255,1) 0%, rgba(255,255,255,1) 12%, rgba(209,209,209,1) 100%);
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ffffff', endColorstr='#d1d1d1', GradientType=0 );
+.hero__name {
+  font-size: clamp(2.5rem, 6vw, 5rem);
+  font-weight: 900;
+  line-height: 1.05;
+  letter-spacing: -2px;
+  background: linear-gradient(135deg, var(--clr-text) 40%, var(--clr-primary-h) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 16px;
 }
 
-.intro .introparagraph{
-	font-size: 40%;
+.hero__title {
+  font-size: clamp(1.1rem, 2.5vw, 1.5rem);
+  font-family: var(--font-mono);
+  color: var(--clr-muted);
+  margin-bottom: 24px;
+  min-height: 2em;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 2px;
+}
+.hero__title-text { color: var(--clr-primary); }
+.hero__cursor {
+  animation: blink 1s step-end infinite;
+  color: var(--clr-primary);
+}
+@keyframes blink { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }
+
+.hero__tagline {
+  font-size: clamp(1rem, 2vw, 1.15rem);
+  color: var(--clr-muted);
+  max-width: 600px;
+  margin: 0 auto 36px;
+  line-height: 1.8;
+}
+.hero__tagline em { color: var(--clr-text); font-style: normal; font-weight: 600; }
+
+.hero__actions {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 56px;
 }
 
-hr.style-two{
-    border: 0;
-    width: 18%;
-    height: 3px;
-    margin-bottom: 0px;
-    background-image: linear-gradient(to right, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0));
+.hero__stats {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0 32px;
+}
+.stat__value {
+  font-size: 2rem;
+  font-weight: 800;
+  color: var(--clr-primary-h);
+  line-height: 1;
+}
+.stat__label {
+  font-size: 0.75rem;
+  color: var(--clr-muted);
+  text-align: center;
+  margin-top: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.stat__divider {
+  width: 1px;
+  height: 40px;
+  background: var(--clr-border);
 }
 
-.style-one{
-	margin: 0 0 20px 1px;
-    border: 0;
-    width: 18%;
-    height: 3px;
-    margin-bottom: 0px;
-    background-image: linear-gradient(to right, rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0.50), rgba(0, 0, 0, 0));
+.hero__scroll {
+  position: absolute;
+  bottom: 32px;
+  left: 50%;
+  transform: translateX(-50%);
+  color: var(--clr-dim);
+  font-size: 1.2rem;
+  animation: float 2s ease-in-out infinite;
+  transition: color var(--transition);
+  z-index: 1;
+}
+.hero__scroll:hover { color: var(--clr-primary); }
+@keyframes float {
+  0%, 100% { transform: translateX(-50%) translateY(0); }
+  50% { transform: translateX(-50%) translateY(8px); }
 }
 
-.nontechnical{
-	margin: 0;
-	padding: 10px 0px 0px 70px;
+/* ---------- BUTTONS ---------- */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 24px;
+  font-family: var(--font-sans);
+  font-size: 0.9rem;
+  font-weight: 600;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  border: none;
+  transition: all var(--transition);
+  white-space: nowrap;
 }
-.skilltypes{
-	margin: 0%;
-	padding: 0px;
-	font-size: 40px;
+.btn--primary {
+  background: var(--clr-primary);
+  color: #fff;
+}
+.btn--primary:hover {
+  background: var(--clr-primary-h);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(99, 102, 241, 0.4);
+}
+.btn--ghost {
+  background: transparent;
+  color: var(--clr-text);
+  border: 1px solid var(--clr-border);
+}
+.btn--ghost:hover {
+  border-color: var(--clr-primary);
+  color: var(--clr-primary);
+  transform: translateY(-2px);
+}
+.btn--lg { padding: 16px 32px; font-size: 1rem; }
+
+/* ---------- SECTIONS ---------- */
+.section {
+  padding: 100px 0;
+  background: var(--clr-bg);
+}
+.section--dark { background: var(--clr-bg-dark); }
+
+.section__header {
+  margin-bottom: 64px;
+}
+.section__label {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--clr-accent);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+.section__title {
+  font-size: clamp(1.8rem, 3.5vw, 2.8rem);
+  font-weight: 800;
+  letter-spacing: -1px;
+  line-height: 1.15;
 }
 
-.bulletpoints{
-	padding-left: 60px;
-	font-size: 18px;
+/* ---------- ABOUT ---------- */
+.about__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 64px;
+  align-items: start;
+}
+.about__text p {
+  color: var(--clr-muted);
+  margin-bottom: 16px;
+  font-size: 1.05rem;
+  line-height: 1.8;
+}
+.about__text p strong { color: var(--clr-text); }
+.about__links {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-top: 28px;
+}
+.about__social {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--clr-muted);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius-sm);
+  transition: all var(--transition);
+}
+.about__social:hover {
+  color: var(--clr-primary);
+  border-color: var(--clr-primary);
+  background: rgba(99, 102, 241, 0.08);
 }
 
-.connectpics{
-	padding: 0 20px;
-	width: 290px;
+.about__highlights { display: flex; flex-direction: column; gap: 16px; }
+
+.highlight-card {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  padding: 20px;
+  background: var(--clr-surface);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius-md);
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+.highlight-card:hover {
+  border-color: rgba(99, 102, 241, 0.4);
+  box-shadow: var(--shadow-glow);
+}
+.highlight-card__icon {
+  width: 40px;
+  height: 40px;
+  min-width: 40px;
+  border-radius: var(--radius-sm);
+  background: rgba(99, 102, 241, 0.15);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--clr-primary);
+  font-size: 1rem;
+}
+.highlight-card h3 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--clr-text);
+  margin-bottom: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.highlight-card p {
+  font-size: 0.875rem;
+  color: var(--clr-muted);
+  line-height: 1.5;
+}
+.highlight-card p + p { margin-top: 2px; }
+
+/* ---------- TIMELINE ---------- */
+.timeline {
+  position: relative;
+  padding-left: 24px;
+}
+.timeline::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 8px;
+  bottom: 8px;
+  width: 2px;
+  background: linear-gradient(to bottom, var(--clr-primary), var(--clr-accent), transparent);
+  border-radius: 2px;
 }
 
-.connectpics2{
-	width: 280px;
+.timeline__item {
+  position: relative;
+  margin-bottom: 56px;
+  padding-left: 32px;
+}
+.timeline__item:last-child { margin-bottom: 0; }
+
+.timeline__marker {
+  position: absolute;
+  left: -31px;
+  top: 6px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--clr-primary);
+  border: 2px solid var(--clr-bg-dark);
+  box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.2);
+}
+.timeline__marker--alt {
+  background: var(--clr-accent);
+  box-shadow: 0 0 0 4px rgba(34, 211, 238, 0.15);
 }
 
-.connectpics2:hover{
-	content: twitcolor.png;
+.timeline__content {
+  background: var(--clr-surface);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius-lg);
+  padding: 28px 32px;
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+.timeline__content:hover {
+  border-color: rgba(99, 102, 241, 0.35);
+  box-shadow: var(--shadow-glow);
 }
 
-.fittingin{
-	background-color: #E17731;
-	color: white;
-	padding: 20px 40px;
-	font-size: 50px;
+.timeline__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+.timeline__role {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--clr-text);
+  margin-bottom: 4px;
+}
+.timeline__company {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--clr-primary);
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  transition: color var(--transition);
+}
+.timeline__company:hover { color: var(--clr-primary-h); }
+.timeline__company i { font-size: 0.7rem; }
+
+.timeline__date {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--clr-muted);
+  background: var(--clr-surface-2);
+  padding: 4px 10px;
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
 }
 
-.fitpic2{
-	max-height: 200px;
-	display: block;
-  	margin-left: auto;
-  	margin-right: auto;
+.timeline__list {
+  list-style: none;
+  margin-bottom: 20px;
+}
+.timeline__list li {
+  position: relative;
+  padding-left: 20px;
+  font-size: 0.925rem;
+  color: var(--clr-muted);
+  line-height: 1.7;
+  margin-bottom: 10px;
+}
+.timeline__list li::before {
+  content: '▸';
+  position: absolute;
+  left: 0;
+  color: var(--clr-primary);
+  font-size: 0.8rem;
+  top: 2px;
+}
+.timeline__list li strong { color: var(--clr-text); }
+
+.timeline__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
 }
 
-.fitpic{
-	text-align: center;
-	padding: 10px 0px 1% 0px;
-	font-size: 15px;
+/* ---------- TAGS ---------- */
+.tag {
+  display: inline-block;
+  padding: 4px 10px;
+  font-size: 0.75rem;
+  font-family: var(--font-mono);
+  font-weight: 500;
+  border-radius: var(--radius-sm);
+  background: var(--clr-surface-2);
+  color: var(--clr-muted);
+  border: 1px solid var(--clr-border);
+  transition: all var(--transition);
+}
+.tag:hover { color: var(--clr-text); border-color: rgba(99,102,241,0.4); }
+
+.tag--strong  { background: rgba(99,102,241,0.12); color: var(--clr-primary-h); border-color: rgba(99,102,241,0.25); }
+.tag--proficient { background: rgba(34,211,238,0.08); color: var(--clr-accent); border-color: rgba(34,211,238,0.2); }
+.tag--infra   { background: rgba(251,191,36,0.08); color: #fbbf24; border-color: rgba(251,191,36,0.2); }
+.tag--leadership { background: rgba(52,211,153,0.08); color: #34d399; border-color: rgba(52,211,153,0.2); }
+
+/* ---------- SKILLS ---------- */
+.skills__grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 24px;
 }
 
-.contact{
-	text-align: center;
-	font-size: 40px;
-	padding: 30px 0px 20px 0px;
+.skill-group {
+  background: var(--clr-surface);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius-lg);
+  padding: 28px;
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+.skill-group:hover {
+  border-color: rgba(99,102,241,0.3);
+  box-shadow: var(--shadow-glow);
+}
+.skill-group__header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+.skill-group__icon {
+  width: 36px; height: 36px;
+  border-radius: var(--radius-sm);
+  background: rgba(99,102,241,0.15);
+  display: flex; align-items: center; justify-content: center;
+  color: var(--clr-primary);
+  font-size: 0.9rem;
+}
+.skill-group h3 {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--clr-text);
+}
+.skill-group__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
-.contactminor{
-	text-align: left;
-	font-size: 15px;
+/* ---------- CONTACT ---------- */
+.contact__body {
+  max-width: 600px;
+  margin: 0 auto;
+  text-align: center;
+}
+.contact__copy {
+  font-size: 1.1rem;
+  color: var(--clr-muted);
+  line-height: 1.8;
+  margin-bottom: 32px;
+}
+.contact__socials {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  margin-top: 32px;
+}
+.social-icon {
+  width: 48px; height: 48px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--clr-border);
+  display: flex; align-items: center; justify-content: center;
+  color: var(--clr-muted);
+  font-size: 1.1rem;
+  transition: all var(--transition);
+}
+.social-icon:hover {
+  color: var(--clr-primary);
+  border-color: var(--clr-primary);
+  background: rgba(99,102,241,0.1);
+  transform: translateY(-3px);
+  box-shadow: 0 8px 20px rgba(99,102,241,0.2);
 }
 
-.tinyfont{
-	color: white;
+/* ---------- FOOTER ---------- */
+.footer {
+  padding: 24px;
+  text-align: center;
+  font-size: 0.825rem;
+  color: var(--clr-dim);
+  background: var(--clr-bg-dark);
+  border-top: 1px solid var(--clr-border);
+}
+.footer strong { color: var(--clr-muted); }
+
+/* ---------- RESPONSIVE ---------- */
+@media (max-width: 768px) {
+  .nav__links {
+    display: none;
+    flex-direction: column;
+    position: absolute;
+    top: 64px;
+    inset-inline: 0;
+    background: rgba(10, 14, 26, 0.97);
+    backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--clr-border);
+    padding: 16px;
+    gap: 4px;
+  }
+  .nav__links.open { display: flex; }
+  .nav__toggle { display: flex; }
+
+  .about__grid { grid-template-columns: 1fr; gap: 40px; }
+  .skills__grid { grid-template-columns: 1fr; }
+  .hero__stats { gap: 24px; }
+  .stat { padding: 0 16px; }
+  .stat__divider { display: none; }
+  .timeline { padding-left: 16px; }
+  .timeline__item { padding-left: 24px; }
+  .timeline__content { padding: 20px; }
+  .timeline__header { flex-direction: column; gap: 8px; }
+}
+
+@media (max-width: 480px) {
+  .section { padding: 72px 0; }
+  .hero { padding: 80px 16px 60px; }
+  .hero__actions { flex-direction: column; align-items: center; }
+  .btn { width: 100%; justify-content: center; }
+  .about__links { flex-direction: column; }
 }

--- a/Styles/main.js
+++ b/Styles/main.js
@@ -1,0 +1,77 @@
+/* ============================================
+   PORTFOLIO JS – POB VUTISALCHAVAKUL
+   ============================================ */
+
+// ---------- NAV SCROLL EFFECT ----------
+const nav = document.getElementById('nav');
+window.addEventListener('scroll', () => {
+  nav.classList.toggle('scrolled', window.scrollY > 40);
+}, { passive: true });
+
+// ---------- MOBILE MENU ----------
+const toggle = document.getElementById('navToggle');
+const links  = document.getElementById('navLinks');
+toggle.addEventListener('click', () => {
+  toggle.classList.toggle('open');
+  links.classList.toggle('open');
+});
+links.querySelectorAll('a').forEach(a => {
+  a.addEventListener('click', () => {
+    toggle.classList.remove('open');
+    links.classList.remove('open');
+  });
+});
+
+// ---------- REVEAL ON SCROLL ----------
+const revealEls = document.querySelectorAll('.reveal');
+const io = new IntersectionObserver(
+  (entries) => {
+    entries.forEach(e => {
+      if (e.isIntersecting) {
+        e.target.classList.add('is-visible');
+        io.unobserve(e.target);
+      }
+    });
+  },
+  { threshold: 0.12, rootMargin: '0px 0px -40px 0px' }
+);
+revealEls.forEach(el => io.observe(el));
+
+// Immediately reveal hero elements (above fold)
+document.querySelectorAll('.hero .reveal').forEach(el => {
+  el.classList.add('is-visible');
+});
+
+// ---------- TYPING EFFECT ----------
+const titleEl = document.getElementById('heroTitle');
+const titles  = [
+  'Senior Software Engineer',
+  'Technology Leader',
+  'Passionate Learner',
+  'Full-Stack Engineer',
+];
+let tIdx = 0, cIdx = 0, deleting = false;
+const MIN_WAIT = 80, DEL_WAIT = 45, PAUSE = 2200;
+
+function type() {
+  const current = titles[tIdx];
+  if (deleting) {
+    titleEl.textContent = current.slice(0, --cIdx);
+    if (cIdx === 0) {
+      deleting = false;
+      tIdx = (tIdx + 1) % titles.length;
+      setTimeout(type, 400);
+      return;
+    }
+    setTimeout(type, DEL_WAIT);
+  } else {
+    titleEl.textContent = current.slice(0, ++cIdx);
+    if (cIdx === current.length) {
+      deleting = true;
+      setTimeout(type, PAUSE);
+      return;
+    }
+    setTimeout(type, MIN_WAIT + Math.random() * 40);
+  }
+}
+setTimeout(type, 1000);

--- a/index.html
+++ b/index.html
@@ -1,398 +1,357 @@
-<!doctype html>
-<html>
-	<head>
-		<title>Meet Pob Vutisalchavakul</title>
-		<link rel="stylesheet" href="Styles/main.css">
-		<!-- Latest compiled and minified CSS -->
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
-
-		<!-- Optional theme -->
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap-theme.min.css">
-
-		<link rel="apple-touch-icon" sizes="57x57" href="icons/apple-touch-icon-57x57.png">
-		<link rel="apple-touch-icon" sizes="60x60" href="icons/apple-touch-icon-60x60.png">
-		<link rel="apple-touch-icon" sizes="72x72" href="icons/apple-touch-icon-72x72.png">
-		<link rel="apple-touch-icon" sizes="76x76" href="icons/apple-touch-icon-76x76.png">
-		<link rel="apple-touch-icon" sizes="114x114" href="icons/apple-touch-icon-114x114.png">
-		<link rel="apple-touch-icon" sizes="120x120" href="icons/apple-touch-icon-120x120.png">
-		<link rel="apple-touch-icon" sizes="144x144" href="icons/apple-touch-icon-144x144.png">
-		<link rel="apple-touch-icon" sizes="152x152" href="icons/apple-touch-icon-152x152.png">
-		<link rel="apple-touch-icon" sizes="180x180" href="icons/apple-touch-icon-180x180.png">
-		<link rel="icon" type="image/png" href="icons/favicon-32x32.png" sizes="32x32">
-		<link rel="icon" type="image/png" href="icons/android-chrome-192x192.png" sizes="192x192">
-		<link rel="icon" type="image/png" href="icons/favicon-96x96.png" sizes="96x96">
-		<link rel="icon" type="image/png" href="icons/favicon-16x16.png" sizes="16x16">
-		<link rel="manifest" href="icon/manifest.json">
-		<meta name="msapplication-TileColor" content="#da532c">
-		<meta name="msapplication-TileImage" content="icon/mstile-144x144.png">
-		<meta name="theme-color" content="#ffffff">
-
-	</head>
-
-	<body>
-
-		<nav class="navbar navbar-default">
-			<div class="container-fluid">
-				<!-- Brand and toggle get grouped for better mobile display -->
-				<div class="navbar-header">
-					<button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
-						<span class="sr-only">Toggle navigation</span>
-						<span class="icon-bar"></span>
-						<span class="icon-bar"></span>
-						<span class="icon-bar"></span>
-					</button>
-					<a class="navbar-brand" href="index.html">ThePobV</a>
-				</div>
-
-				<!-- Collect the nav links, forms, and other content for toggling -->
-				<div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-					<ul class="nav navbar-nav">
-
-						<li ><a href="index.html"> Home <span class="sr-only"></span></a></li>
-
-						<li ><a href="resume.html"> Resume <span class="sr-only"></span></a></li>
-
-						<li ><a href="https://www.linkedin.com/in/vutisat" target="_blank"> LinkedIn <span class="sr-only"></span></a></li>
-
-						<li><a href="https://www.github.com/vutisat" target="_blank" >Github</a></li>
-
-						<li class="dropdown">
-							<a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><span class="caret"></span></a>
-							<ul class="dropdown-menu">
-								<img src="http://i0.kym-cdn.com/entries/icons/facebook/000/014/959/Screenshot_116.jpg" style="max-height: 300px"alt="">
-								<!--<li role="separator" class="divider"></li>-->
-								<li style="text-align: center">Thank you for visiting!</li>
-							</ul>
-						</li>
-					</ul>
-
-
-				</div><!-- /.navbar-collapse -->
-			</div><!-- /.container-fluid -->
-		</nav>
-
-
-		<div class="warning col-sm-12" style="margin:0;">
-				<p class="text-center">WEBSITE IS UNDER CONSTRUCTION</p>
-				<p class="text-center" style="font-size: 15px;"> (Haven't looked for a job in years, should be fully updated in matter of days.)</p>
-			</div>
-
-		<div class="introcon">
-			<div class="introcon container">
-				<div class="pobbody col-sm-6">
-					<img src="pobbody.png" class="pobbody img-responsive img-small" style="margin-right: 60px; float: right; float: bottom; width:350px; height:500px;">
-				</img>
-				</div>
-
-				<div class="intro col-sm-6">
-					<p><strong>Hello!</strong> <br>I'm Pob.</br> </p>
-					<div class="introparagraph">
-						<p>I'm a Computer Science student at Miami University.
-						I would love to be part of your team and create awesome things together!
-					</p>
-					</div>
-
-				</div>
-			</div>
-		</div>
-
-
-			<div class="workwith col-sm-12">
-				<p class="text-center ">I would like to be on your team this summer! (June - August)</p>
-			</div>
-
-			<div class="skillset col-sm-12" >
-				<p class="text-center" style="margin-bottom: 10px;">What can I do?
-						<hr class="style-two">
-				</p>
-
-				<div class="container">
-					<div class="nontechnical">
-					<p class="skilltypes">
-						<strong>Non-Technical Skills</strong>
-						<hr class="style-one">
-
-						<div class="col-sm-12" style="font-size: 30px;">
-							<img src="bullet2.png" alt=""> Leadership
-
-							<ul class="bulletpoints">
-								<li> <a href="http://miamioh.edu/cec/_files/documents/lockheed/brochure-2014/index2.html"> Lockheed Martin Leadership Institute</a>
-									<ul class="subbulletpoints">
-										<li>Three-year certificate program that aims to develop technical/innovative leadership, business 	acumen, people leadership and personal/ethical leadership
-										<li>Interacted with various leaders of Fortune 500 companies to develop leadership skills
-									</ul>
-								<li> <a href="http://miamioh.edu/cec/centers-institutes/lockheed-martin/eweek/index.html"> Engineers Week Head Coordinator</a>
-									<ul class="subbulletpoints">
-										<li>Lead and delegated over 30 students to coordinate a week-long event to promote the awareness and importance of engineering
-										<li>Supervised an <a href="http://miamioh.edu/cec/events/e-week2015/start-the-trend-challenge/index.html">all-day event</a> to promote women in engineering with ~200 participants
-									</ul>
-							</ul>
-
-							<img src="bullet2.png" alt=""> Teamwork
-
-							<ul class="bulletpoints">
-								<li> Camp Instructor
-									<ul>
-										<li>Maintained and administered classes for 200+ kids (8-18 y/o) as a camp instructor with <a href="https://www.idtech.com/courses/programming/">iD Tech</a> along with four other collegues
-									</ul>
-								<li>Projects Team Member
-									<ul>
-										<li>Engaged in many team projects in the past, ranging from softwares (<a href="https://github.com/Vutisat/Hungry-in-Oxford">Hungry in Oxford</a>
-											, <a href="https://play.google.com/store/apps/details?id=org.zdev.recall&hl=en">ReCall</a>) to non-software (<a href="http://miamioh.edu/cec/events/e-week2015/index.html">Engineers Week</a>, <a href="https://muunicef.wordpress.com/events/">UNICEF Fundraising</a>)
-									</ul>
-
-							</ul>
-
-							<img src="bullet2.png" alt=""> Communication
-
-							<ul class="bulletpoints">
-								<li> Experienced with the agile methodology
-								<li> Have the ability to write concisely and logically
-								<li> Not afraid of asking questions when appropriate
-								<li> Fluent in Thai and English
-							</ul>
-
-
-						</div>
-							<strong>Technical Skills</strong>
-							<hr class="style-one">
-							</p>
-					</div>
-
-						<div class="nontechnical">
-						<div class="col-sm-12" style="font-size: 30px;">
-
-							<img src="bullet2.png" alt=""> Front End
-
-								<ul class="bulletpoints">
-									<li> HTML, CSS, JavaScript, jQuery
-								</ul>
-
-							<img src="bullet2.png" alt=""> Back End
-
-								<ul class="bulletpoints">
-									<li> Python, Node.js
-								</ul>
-
-							<img src="bullet2.png" alt=""> Mobile Developement
-
-								<ul class="bulletpoints">
-									<li> Android
-										<ul class="subbulletpoints">
-											<li><a href="https://play.google.com/store/apps/details?id=org.zdev.recall&hl=en">ReCall</a> - an app that tracks your clipboard usage.
-										</ul>
-								</ul>
-							<img src="bullet2.png" alt=""> Functional Software development
-
-								<ul class="bulletpoints">
-									<li>Experienced with:
-										<ul class="subbulletpoints">
-											<li> Java, Python
-										</ul>
-									<li>Comfortable with:
-										<ul class="subbulletpoints">
-											<li> C++, JavaScript
-										</ul>
-									<li>Played with:
-										<ul class="subbulletpoints">
-											<li> (Scheme/Lisp, Racket, Prolog)
-										</ul>
-								</ul>
-							<img src="bullet2.png" alt=""> Database management
-
-								<ul class="bulletpoints">
-									<li> SQL (MySQL, SQLite)
-										<ul class="subbulletpoints">
-											<li>Familiar with relational algebra & database normalization
-										</ul>
-								</ul>
-						</div>
-
-					<!--
-						<div class="col-sm-1" style="font-size: 30px;">
-							<p style="font-size:80px;">}
-							<br>}
-						<br>}
-						</p>
-
-						<div class="col-sm-6" style="font-size: 30px;">
-							testing
-							<ul>
-								<li>A</li>
-								<li>B</li>
-								<li>C</li>
-								<li>D</li>
-								<li>E</li>
-							</ul>
-						</div>
-					-->
-					</div>
-				</div>
-
-				</div>
-
-
-				<div class="fittingin col-sm-12">
-					<p class="text-center ">Will I fit your team?</p>
-
-				<!-- Images 1-4 -->
-					<div class="container">
-						<div class="fitpic col-sm-3 col-xs-6">
-							<img src="pictures/bball.jpg" alt="" class="fitpic2 img-responsive img-center img-rounded">
-							<br><strong>Basketball</strong>
-							<br>A fan of being on the court as wekk as watching the game!
-						</div>
-
-						<div class="fitpic col-sm-3 col-xs-6">
-							<img src="pictures/beer.jpg" alt="" class="fitpic2 img-responsive img-rounded">
-							<br><strong>Happy Hours</strong>
-							<br>I'd love to grab a drink after work with the team!
-						</div>
-
-						<div class="fitpic col-sm-3 col-xs-6">
-							<img src="pictures/cs.png" alt="" class="fitpic2 img-responsive img-rounded">
-							<br><strong>Computer Science</strong>
-							<br>Always cool to learn about different solutions to complex problems!
-						</div>
-
-						<div class="fitpic col-sm-3 col-xs-6">
-							<img src="pictures/golden.jpg" alt="" class="fitpic2 img-responsive img-rounded">
-							<br><strong>Dogs</strong>
-							<br>I love dogs!
-						</div>
-					</div>
-				<!-- Images 1-4 finished -->
-
-				<!-- Images 5-8 -->
-					<div class="container">
-						<div class="fitpic col-sm-3 col-xs-6">
-							<img src="pictures/tyson.jpg" alt="" class="fitpic2 img-responsive img-rounded">
-							<br><strong>Technology and Science</strong>
-							<br>I'm constantly excited to learn about them.
-						</div>
-
-						<div class="fitpic col-sm-3 col-xs-6">
-							<img src="pictures/travel.png" alt="" class="fitpic2 img-responsive img-rounded">
-							<br><strong>Traveling</strong>
-							<br>Love to explore new places!
-						</div>
-
-						<div class="fitpic col-sm-3 col-xs-6">
-							<img src="pictures/volunteer.jpg" alt="" class="fitpic2 img-responsive img-rounded">
-							<br><strong>Volunteering</strong>
-							<br>I always enjoy a chance to help others!
-						</div>
-
-						<div class="fitpic col-sm-3 col-xs-6">
-							<img src="pictures/more.jpg" alt="" class="fitpic2 img-responsive img-rounded">
-							<br><strong>???</strong>
-							<br>Music, TV Shows, Books, Latest Events, I'm sure we have many interests in common!
-						</div>
-
-					</div>
-				<!-- Images 5-8 finished -->
-				</div>
-
-			<div id="contact" class="contact">
-				<br>Contact me
-
-				<br>
-				<div style="font-size: 20px;">I welcome you to contact me at <a href="Vutisat@miamioh.edu">Vutisat@MiamiOH.edu</a>!</div>
-				<div class="contactminor container">
-
-
-					<!-- <form action="index.php" method="post" name="contact_form">
-
-						  <div class="form-group">
-						    <label for="inputName">Name</label>
-						    <input type="text" class="form-control" id="inputName" name="name" placeholder="John Smith">
-						  </div>
-						  <div class="form-group">
-						    <label for="inputEmail">Email</label>
-						    <input type="email" class="form-control" id="inputEmail" name="email" placeholder="John.Smith@example.com">
-						  </div>
-
-
-						<label for"inputMessage">Your Message:</label>
-						<textarea class="form-control" rows="6" id="inputMessage" name="msgtext" placeholder="Please type your message here."></textarea>
-						<br>
-					  <button type="submit" id="submit" name="submit" class="btn btn-default">Submit</button>
-					</form> -->
-
-				</div>
-			</div>
-
-			<div class="letsconnect col-sm-12">
-				<p class="text-center ">Let's connect!</p>
-				<div class="row text-center">
-					<a href="https://twitter.com/pob_v"> <img class="img-fluid" id="linkedin" src="linkedinbanner.png">
-					</a>
-
-					<a href="https://www.github.com/vutisat"><img class="connectpics img-fluid" id="github" src="githubbanner.png">
-					</a>
-					<a href="https://twitter.com/pob_v">
-						<img class="connectpics2 img-fluid" id="twitter" src="twitterbanner.png">
-					</a>
-				</div>
-			</div>
-
-		<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
-
-		<script src="bower_components/jquery/jquery.js"></script>
-		<script>
-			$(function(){
-
-				/*$('#submit').('click', function()
-				{
-					$.ajax({
-						url: index.php,
-						type:'POST',
-						data:
-						{
-							name: inputName,
-							email: inputEmail,
-							message: inputMessage
-						},
-						success: function(msg)
-						{
-							alert('Email Sent');
-						}
-					});
-				});*/
-
-				$("#twitter").on({"mouseover" : function() {
-						this.src = 'twitcolor.png';
-					},
-					"mouseout" : function() {
-						this.src='twitterbanner.png';
-					}
-				});
-
-				$("#github").on({"mouseover" : function() {
-						this.src = 'github2.png';
-					},
-					"mouseout" : function() {
-						this.src='githubbanner.png';
-					}
-				});
-
-				$("#linkedin").on({"mouseover" : function() {
-						this.src = 'linkedin2.png';
-					},
-					"mouseout" : function() {
-						this.src='linkedinbanner.png';
-					}
-				});
-
-			});
-		</script>
-<!-- End jQuery -->
-
-		<!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-		<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-		<!-- Include all compiled plugins (below), or include individual files as needed -->
-		<script src="js/bootstrap.min.js"></script>
-		<!-- Latest compiled and minified JavaScript -->
-		<script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
-	</body>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pob Vutisalchavakul – Senior Software Engineer</title>
+
+  <link rel="apple-touch-icon" sizes="180x180" href="icons/apple-touch-icon-180x180.png">
+  <link rel="icon" type="image/png" href="icons/favicon-32x32.png" sizes="32x32">
+  <link rel="icon" type="image/png" href="icons/favicon-16x16.png" sizes="16x16">
+  <meta name="theme-color" content="#0a0e1a">
+  <meta name="description" content="Pob Vutisalchavakul – Senior Software Engineer passionate about continuous learning, leading high-performing teams, and building systems at scale.">
+
+  <!-- Google Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+
+  <!-- Font Awesome -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+
+  <link rel="stylesheet" href="Styles/main.css">
+</head>
+<body>
+
+  <!-- ========== NAVIGATION ========== -->
+  <nav class="nav" id="nav">
+    <div class="nav__inner">
+      <a href="#hero" class="nav__logo">pob<span>.</span>dev</a>
+      <button class="nav__toggle" id="navToggle" aria-label="Toggle menu">
+        <span></span><span></span><span></span>
+      </button>
+      <ul class="nav__links" id="navLinks">
+        <li><a href="#about" class="nav__link">About</a></li>
+        <li><a href="#experience" class="nav__link">Experience</a></li>
+        <li><a href="#skills" class="nav__link">Skills</a></li>
+        <li><a href="#contact" class="nav__link">Contact</a></li>
+        <li><a href="resume.pdf" target="_blank" class="nav__cta">Resume <i class="fa-solid fa-arrow-up-right-from-square"></i></a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <!-- ========== HERO ========== -->
+  <section class="hero" id="hero">
+    <div class="hero__bg">
+      <div class="hero__grid"></div>
+      <div class="hero__glow hero__glow--1"></div>
+      <div class="hero__glow hero__glow--2"></div>
+    </div>
+    <div class="hero__content">
+      <p class="hero__greeting reveal">Hi, I'm</p>
+      <h1 class="hero__name reveal reveal--delay-1">Pob Vutisalchavakul</h1>
+      <div class="hero__title reveal reveal--delay-2">
+        <span class="hero__title-text" id="heroTitle">Senior Software Engineer</span>
+        <span class="hero__cursor">|</span>
+      </div>
+      <p class="hero__tagline reveal reveal--delay-3">
+        Energetic technology leader with a passion for <em>continuous learning</em> and building systems that scale to <em>petabytes of data</em> and <em>millions of daily users</em>.
+      </p>
+      <div class="hero__actions reveal reveal--delay-4">
+        <a href="#experience" class="btn btn--primary">See My Work</a>
+        <a href="#contact" class="btn btn--ghost">Get In Touch</a>
+      </div>
+      <div class="hero__stats reveal reveal--delay-5">
+        <div class="stat">
+          <span class="stat__value">7+</span>
+          <span class="stat__label">Years of Experience</span>
+        </div>
+        <div class="stat__divider"></div>
+        <div class="stat">
+          <span class="stat__value">$B+</span>
+          <span class="stat__label">Systems Supported</span>
+        </div>
+        <div class="stat__divider"></div>
+        <div class="stat">
+          <span class="stat__value">10M+</span>
+          <span class="stat__label">Daily Requests Handled</span>
+        </div>
+      </div>
+    </div>
+    <a href="#about" class="hero__scroll" aria-label="Scroll down">
+      <i class="fa-solid fa-chevron-down"></i>
+    </a>
+  </section>
+
+  <!-- ========== ABOUT ========== -->
+  <section class="section" id="about">
+    <div class="container">
+      <div class="section__header reveal">
+        <span class="section__label">01. About</span>
+        <h2 class="section__title">Who I Am</h2>
+      </div>
+      <div class="about__grid">
+        <div class="about__text reveal">
+          <p>
+            I'm a <strong>Senior Software Engineer</strong> based in NYC with a passion for building clean, robust systems at scale. I thrive at the intersection of great engineering and great culture — celebrated as a servant leader who brings the best out of teams.
+          </p>
+          <p>
+            My career has spanned full-stack development, distributed systems, and technical leadership across companies like <strong>Datasite</strong> and <strong>Target</strong> — building everything from billing systems processing billions of dollars to data pipelines ingesting petabytes of information.
+          </p>
+          <p>
+            Outside of code, I'm an avid traveler (bilingual: Thai/English), a basketball fan, and a relentless mentor. I believe the best engineers are the ones who never stop learning — and I live that every day.
+          </p>
+          <div class="about__links">
+            <a href="https://www.linkedin.com/in/vutisat/" target="_blank" rel="noopener" class="about__social">
+              <i class="fa-brands fa-linkedin"></i> LinkedIn
+            </a>
+            <a href="https://www.github.com/vutisat" target="_blank" rel="noopener" class="about__social">
+              <i class="fa-brands fa-github"></i> GitHub
+            </a>
+            <a href="https://twitter.com/pob_v" target="_blank" rel="noopener" class="about__social">
+              <i class="fa-brands fa-x-twitter"></i> Twitter
+            </a>
+          </div>
+        </div>
+        <div class="about__highlights reveal reveal--delay-1">
+          <div class="highlight-card">
+            <div class="highlight-card__icon"><i class="fa-solid fa-graduation-cap"></i></div>
+            <div>
+              <h3>Education</h3>
+              <p>B.S. Computer Science — Miami University, 2016</p>
+              <p>Mini-MBA — Farmer School of Business, 2021</p>
+            </div>
+          </div>
+          <div class="highlight-card">
+            <div class="highlight-card__icon"><i class="fa-solid fa-location-dot"></i></div>
+            <div>
+              <h3>Location</h3>
+              <p>Remote / NYC</p>
+            </div>
+          </div>
+          <div class="highlight-card">
+            <div class="highlight-card__icon"><i class="fa-solid fa-heart"></i></div>
+            <div>
+              <h3>Interests</h3>
+              <p>Continuous learning, basketball, traveling, mentoring, volunteering</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ========== EXPERIENCE ========== -->
+  <section class="section section--dark" id="experience">
+    <div class="container">
+      <div class="section__header reveal">
+        <span class="section__label">02. Experience</span>
+        <h2 class="section__title">Where I've Worked</h2>
+      </div>
+
+      <div class="timeline">
+
+        <div class="timeline__item reveal">
+          <div class="timeline__marker"></div>
+          <div class="timeline__content">
+            <div class="timeline__header">
+              <div>
+                <h3 class="timeline__role">Senior Software Engineer</h3>
+                <a href="https://www.datasite.com" target="_blank" rel="noopener" class="timeline__company">Datasite <i class="fa-solid fa-arrow-up-right-from-square"></i></a>
+              </div>
+              <span class="timeline__date">Summer 2018 – Present</span>
+            </div>
+            <ul class="timeline__list">
+              <li>Developed and maintained a highly sensitive <strong>billing system</strong> processing <strong>billions of dollars</strong> with accuracy down to every penny — directly impacting thousands of clients and the company's bottom line.</li>
+              <li>Built an internal event-capture library now used by many teams, powering a <strong>petabyte-scale data warehouse</strong> for analytics and SOX/FEC reporting.</li>
+              <li>Architected and delivered a secure <strong>email service</strong> used firm-wide for all outgoing communications.</li>
+              <li>Led the team that <strong>completely revamped Datasite's landing page</strong>, revolutionizing its look & feel and streamlining usage with real-time notifications and insightful analytics.</li>
+              <li>Lead contributor on <strong>Datasite Outreach</strong> — designed GraphQL, Node, and SpringBoot APIs; implemented a Salesforce data integration system; and orchestrated the full production-readiness infrastructure (monitoring, alerts, scaling).</li>
+              <li>Contributed to major architectural decisions and mentored fellow developers across the organization.</li>
+            </ul>
+            <div class="timeline__tags">
+              <span class="tag">Java</span><span class="tag">Groovy</span><span class="tag">GraphQL</span><span class="tag">Node.js</span><span class="tag">SpringBoot</span><span class="tag">React</span><span class="tag">Snowflake</span><span class="tag">Kafka</span><span class="tag">Kubernetes</span><span class="tag">Salesforce</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="timeline__item reveal">
+          <div class="timeline__marker"></div>
+          <div class="timeline__content">
+            <div class="timeline__header">
+              <div>
+                <h3 class="timeline__role">Software Engineer</h3>
+                <a href="https://www.target.com" target="_blank" rel="noopener" class="timeline__company">Target <i class="fa-solid fa-arrow-up-right-from-square"></i></a>
+              </div>
+              <span class="timeline__date">Summer 2016 – Summer 2018</span>
+            </div>
+            <ul class="timeline__list">
+              <li>Built a feature in Target.com's data aggregator to deliver <strong>real-time in-store item pricing</strong> — serving over <strong>10 million hits per day</strong> at 95%+ sub-second response times.</li>
+              <li>Developed the front-end for the Social Migration feature in the Cartwheel app, experienced by <strong>15 million users</strong>.</li>
+              <li>Spearheaded a full-stack project enabling Target to expedite <strong>$100k+ of orders</strong> (and growing), end-to-end.</li>
+              <li>Stood up a new API enabling Target Mobile Apps to display <strong>in-store item locations</strong> for guests.</li>
+              <li>Used <strong>D3.js and C3.js</strong> to build elegant data visualizations for Target's Big Data Platform (Hadoop) consumer dashboards.</li>
+            </ul>
+            <div class="timeline__tags">
+              <span class="tag">Java</span><span class="tag">JavaScript</span><span class="tag">D3.js</span><span class="tag">C3.js</span><span class="tag">Hadoop</span><span class="tag">REST APIs</span><span class="tag">Microservices</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="timeline__item reveal">
+          <div class="timeline__marker"></div>
+          <div class="timeline__content">
+            <div class="timeline__header">
+              <div>
+                <h3 class="timeline__role">Software Engineer</h3>
+                <a href="https://www.studysync.com" target="_blank" rel="noopener" class="timeline__company">StudySync (McGraw-Hill Education) <i class="fa-solid fa-arrow-up-right-from-square"></i></a>
+              </div>
+              <span class="timeline__date">Fall 2015 – Summer 2016</span>
+            </div>
+            <ul class="timeline__list">
+              <li>Developed a third-party API integration allowing users to access their library of books synced to StudySync courses, using <strong>CoffeeScript, Node.js, and AngularJS</strong>.</li>
+              <li>Implemented myriad front-end features directly from teacher and student feedback, shipping iterative improvements.</li>
+            </ul>
+            <div class="timeline__tags">
+              <span class="tag">Node.js</span><span class="tag">AngularJS</span><span class="tag">CoffeeScript</span><span class="tag">REST APIs</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="timeline__item reveal">
+          <div class="timeline__marker timeline__marker--alt"></div>
+          <div class="timeline__content">
+            <div class="timeline__header">
+              <div>
+                <h3 class="timeline__role">Leadership Fellow</h3>
+                <span class="timeline__company">Lockheed Martin Leadership Institute</span>
+              </div>
+              <span class="timeline__date">Fall 2013 – Summer 2016</span>
+            </div>
+            <ul class="timeline__list">
+              <li>Completed a <strong>three-year certificate program</strong> developing technical leadership, business acumen, and ethical leadership through workshops and sessions with Fortune 500 executives.</li>
+              <li>Ignited a movement to fight engineer stereotypes, sparking the global Twitter trend <strong>#IAmAnEngineer</strong>.</li>
+            </ul>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </section>
+
+  <!-- ========== SKILLS ========== -->
+  <section class="section" id="skills">
+    <div class="container">
+      <div class="section__header reveal">
+        <span class="section__label">03. Skills</span>
+        <h2 class="section__title">What I Work With</h2>
+      </div>
+
+      <div class="skills__grid">
+        <div class="skill-group reveal">
+          <div class="skill-group__header">
+            <div class="skill-group__icon"><i class="fa-solid fa-star"></i></div>
+            <h3>Strong</h3>
+          </div>
+          <div class="skill-group__tags">
+            <span class="tag tag--strong">Java</span>
+            <span class="tag tag--strong">Groovy</span>
+            <span class="tag tag--strong">JVM</span>
+            <span class="tag tag--strong">Spring Boot</span>
+            <span class="tag tag--strong">Microservices</span>
+            <span class="tag tag--strong">Spock</span>
+            <span class="tag tag--strong">TDD</span>
+          </div>
+        </div>
+        <div class="skill-group reveal reveal--delay-1">
+          <div class="skill-group__header">
+            <div class="skill-group__icon"><i class="fa-solid fa-bolt"></i></div>
+            <h3>Proficient</h3>
+          </div>
+          <div class="skill-group__tags">
+            <span class="tag tag--proficient">Python</span>
+            <span class="tag tag--proficient">TypeScript</span>
+            <span class="tag tag--proficient">Node.js</span>
+            <span class="tag tag--proficient">React / Redux</span>
+            <span class="tag tag--proficient">GraphQL</span>
+            <span class="tag tag--proficient">D3.js</span>
+            <span class="tag tag--proficient">SQL</span>
+            <span class="tag tag--proficient">NoSQL</span>
+            <span class="tag tag--proficient">HTML/CSS</span>
+          </div>
+        </div>
+        <div class="skill-group reveal reveal--delay-2">
+          <div class="skill-group__header">
+            <div class="skill-group__icon"><i class="fa-solid fa-server"></i></div>
+            <h3>Infrastructure & Data</h3>
+          </div>
+          <div class="skill-group__tags">
+            <span class="tag tag--infra">Kubernetes</span>
+            <span class="tag tag--infra">Docker</span>
+            <span class="tag tag--infra">Kafka</span>
+            <span class="tag tag--infra">RabbitMQ</span>
+            <span class="tag tag--infra">PostgreSQL</span>
+            <span class="tag tag--infra">MongoDB</span>
+            <span class="tag tag--infra">Snowflake</span>
+            <span class="tag tag--infra">ELK Stack</span>
+            <span class="tag tag--infra">PCF / Azure</span>
+            <span class="tag tag--infra">Drone CI</span>
+          </div>
+        </div>
+        <div class="skill-group reveal reveal--delay-3">
+          <div class="skill-group__header">
+            <div class="skill-group__icon"><i class="fa-solid fa-people-group"></i></div>
+            <h3>Leadership & Process</h3>
+          </div>
+          <div class="skill-group__tags">
+            <span class="tag tag--leadership">Servant Leadership</span>
+            <span class="tag tag--leadership">Agile / Scrum</span>
+            <span class="tag tag--leadership">Mentoring</span>
+            <span class="tag tag--leadership">Design Thinking</span>
+            <span class="tag tag--leadership">Usability Studies</span>
+            <span class="tag tag--leadership">System Architecture</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ========== CONTACT ========== -->
+  <section class="section section--dark" id="contact">
+    <div class="container">
+      <div class="section__header reveal">
+        <span class="section__label">04. Contact</span>
+        <h2 class="section__title">Let's Connect</h2>
+      </div>
+      <div class="contact__body reveal">
+        <p class="contact__copy">
+          Whether you have an opportunity, a challenging problem, or just want to talk engineering — my inbox is open.
+        </p>
+        <a href="mailto:Vutisat@MiamiOH.edu" class="btn btn--primary btn--lg">
+          <i class="fa-solid fa-envelope"></i> Say Hello
+        </a>
+        <div class="contact__socials">
+          <a href="https://www.linkedin.com/in/vutisat/" target="_blank" rel="noopener" class="social-icon" aria-label="LinkedIn">
+            <i class="fa-brands fa-linkedin-in"></i>
+          </a>
+          <a href="https://www.github.com/vutisat" target="_blank" rel="noopener" class="social-icon" aria-label="GitHub">
+            <i class="fa-brands fa-github"></i>
+          </a>
+          <a href="https://twitter.com/pob_v" target="_blank" rel="noopener" class="social-icon" aria-label="Twitter / X">
+            <i class="fa-brands fa-x-twitter"></i>
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ========== FOOTER ========== -->
+  <footer class="footer">
+    <div class="container">
+      <p>Designed & built by <strong>Pob Vutisalchavakul</strong></p>
+    </div>
+  </footer>
+
+  <script src="Styles/main.js"></script>
+</body>
 </html>


### PR DESCRIPTION
Complete redesign using the resume data — dark navy/indigo color palette,
animated hero with typing effect, timeline experience layout, skill grid,
scroll-reveal animations, and a sticky responsive nav. Removes the old
Bootstrap 3 site and replaces it with clean vanilla HTML/CSS/JS using
Inter & JetBrains Mono from Google Fonts plus Font Awesome icons.

https://claude.ai/code/session_013qzpPSFdnJLgQWHgRqmXV1